### PR TITLE
wrap-multilines rule is deprecated #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is a baseline configuration for linting React/JSX files using [eslint-plugi
   - __v2__ - for `eslint` >= 1.4 / < 2.0 and `eslint-plugin-react` >= 3 / < 4
   - __v3__ - for `eslint` >= 2.0 and `eslint-plugin-react` >= 4
   - __v4__ - for `eslint` >= 3.0 and `eslint-plugin-react` >= 6
+  - __v5__ - for `eslint` >= 4.0 and `eslint-plugin-react` >= 7
 
 
 #### Usage

--- a/index.js
+++ b/index.js
@@ -45,6 +45,6 @@ module.exports = {
     "react/self-closing-comp": 2,
     "react/sort-comp": 2,
     "react/sort-prop-types": [2, { "ignoreCase": true }],
-    "react/wrap-multilines": 2
+    "react/jsx-wrap-multilines": 2
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-react",
-  "version": "3.0.0",
+  "version": "5.0.0",
   "description": " ",
   "main": "index.js",
   "scripts": {
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/360incentives/eslint-config-react",
   "devDependencies": {
-    "eslint": "^2",
-    "eslint-plugin-react": "^4"
+    "eslint": "^4",
+    "eslint-plugin-react": "^7"
   }
 }


### PR DESCRIPTION
Replaced wrap-multilines rule with jsx-wrap-multilines as the former is deprecated. Fix for #8 